### PR TITLE
 Add __version__ number in __init__.py

### DIFF
--- a/keras_lookahead/__init__.py
+++ b/keras_lookahead/__init__.py
@@ -1,1 +1,3 @@
 from .optimizers import *
+
+__version__ = '0.7.0'

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,30 @@
 import codecs
+import re
+
+from setuptools import setup, find_packages
+from os import path
+
+here = path.abspath(path.dirname(__file__))
+
+
+def get_requirements(*parts):
+    with codecs.open(path.join(here, *parts), 'r', 'utf8') as fp:
+        return list(map(lambda x: x.strip(), fp.readlines()))
+
+
+def read(*parts):
+    with codecs.open(path.join(here, *parts), 'r', 'utf8') as fp:
+        return fp.read()
+
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
 from setuptools import setup, find_packages
 
 with codecs.open('README.md', 'r', 'utf8') as reader:
@@ -11,19 +37,19 @@ with codecs.open('requirements.txt', 'r', 'utf8') as reader:
 
 setup(
     name='keras-lookahead',
-    version='0.6.0',
+    version=find_version('keras_lookahead', '__init__.py'),
     packages=find_packages(),
     url='https://github.com/CyberZHG/keras-lookahead',
     license='MIT',
     author='CyberZHG',
     author_email='CyberZHG@users.noreply.github.com',
     description='Lookahead mechanism for optimizers in Keras',
-    long_description=long_description,
+    long_description=read('README.md'),
     long_description_content_type='text/markdown',
-    install_requires=install_requires,
-    classifiers=(
+    install_requires=get_requirements('requirements.txt'),
+    classifiers=[
         "Programming Language :: Python :: 3.6",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
-    ),
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -25,15 +25,6 @@ def find_version(*file_paths):
         return version_match.group(1)
     raise RuntimeError("Unable to find version string.")
 
-from setuptools import setup, find_packages
-
-with codecs.open('README.md', 'r', 'utf8') as reader:
-    long_description = reader.read()
-
-
-with codecs.open('requirements.txt', 'r', 'utf8') as reader:
-    install_requires = list(map(lambda x: x.strip(), reader.readlines()))
-
 
 setup(
     name='keras-lookahead',


### PR DESCRIPTION
While I'm at it:

> Currently the standard variable __version__ is not set, and one must use pkg_resources to determine the version number at runtime.
> 
> "Be aware that the pkg_resources API only knows about what’s in the installation metadata, which is not necessarily the code that’s currently imported."
> 
> This PR add a single __version__ variable in __init__.py to be able to access the library version number at runtime.
> 
> Note that this code allows to run python setup.py --version.
> 
> This is inspired from: https://packaging.python.org/guides/single-sourcing-package-version/.
> 
> Also correct a warning when using tuple instead of list for the field classifiers.
> 
> Another solution would be to create a dedicated version.py file as in tensorflow_addons: https://github.com/tensorflow/addons/blob/master/tensorflow_addons/version.py

See: https://github.com/CyberZHG/keras-radam/pull/34